### PR TITLE
Deploy pushbot:latest now that the migration branch is merged

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -15,7 +15,7 @@ security_group_id=sg-37394a4a
 timeout=120
 
 [pushbot]
-branch=k8s-and-postgres
+branch=latest
 admins=U02D23B7J,U02D23G6N
 betray_immune=U02D23B7J,U02D23G6N,U02D25HJG,U02D1CX67
 dnd_public_channel=C31NEFF89

--- a/config.ini
+++ b/config.ini
@@ -15,13 +15,13 @@ security_group_id=sg-37394a4a
 timeout=120
 
 [pushbot]
-branch=latest
+tag=latest
 admins=U02D23B7J,U02D23G6N
 betray_immune=U02D23B7J,U02D23G6N,U02D25HJG,U02D1CX67
 dnd_public_channel=C31NEFF89
 
 [nginx]
-branch=latest
+tag=latest
 
 [tls]
-branch=latest
+tag=latest

--- a/provision/config.py
+++ b/provision/config.py
@@ -25,13 +25,13 @@ class Config:
 
         self.rds_security_group_id = public_ini.get('rds', 'security_group_id')
         self.bootstrap_timeout = public_ini.getint('bootstrap', 'timeout')
-        self.pushbot_branch = public_ini.get('pushbot', 'branch')
+        self.pushbot_tag = public_ini.get('pushbot', 'tag')
         self.pushbot_admins = public_ini.get('pushbot', 'admins')
         self.pushbot_betray_immune = public_ini.get('pushbot', 'betray_immune')
         self.pushbot_dnd_public_channel = public_ini.get('pushbot', 'betray_immune')
 
-        self.azurefire_nginx_branch = public_ini.get('nginx', 'branch')
-        self.azurefire_tls_branch = public_ini.get('tls', 'branch')
+        self.azurefire_nginx_tag = public_ini.get('nginx', 'tag')
+        self.azurefire_tls_tag = public_ini.get('tls', 'tag')
 
         self.resource_id = int(time.time())
         self.build_id = os.environ.get('TRAVIS_BUILD_ID', '0')

--- a/provision/template.py
+++ b/provision/template.py
@@ -20,17 +20,17 @@ def template_payload(context):
 
     return {
         'pushbot': {
-            'branch': context.config.pushbot_branch,
+            'tag': context.config.pushbot_tag,
             'dnd_public_channel': context.config.pushbot_dnd_public_channel,
             'admins': context.config.pushbot_admins,
             'betray_immune': context.config.pushbot_betray_immune,
             'prior_addresses': prior_addresses
         },
         'nginx': {
-            'branch': context.config.azurefire_nginx_branch
+            'tag': context.config.azurefire_nginx_tag
         },
         'tls': {
-            'branch': context.config.azurefire_tls_branch
+            'tag': context.config.azurefire_tls_tag
         },
         'letsencrypt': {
             'email': context.config.le_email

--- a/template/bootstrap.sh.j2
+++ b/template/bootstrap.sh.j2
@@ -52,8 +52,8 @@ report_versions()
 }
 
 multipull \
-  quay.io/smashwilson/pushbot:{{ pushbot.branch }} \
-  quay.io/smashwilson/azurefire-nginx:{{ nginx.branch }}
+  quay.io/smashwilson/pushbot:{{ pushbot.tag }} \
+  quay.io/smashwilson/azurefire-nginx:{{ nginx.tag }}
 
 # Install a timer to automatically renew the TLS certificates.
 
@@ -67,7 +67,7 @@ Type=oneshot
 ExecStart=/usr/bin/docker run --rm \
   --env EMAIL={{ letsencrypt.email }} \
   --env LE_PRODUCTION=yes \
-  quay.io/smashwilson/azurefire-tls:{{ tls.branch }}
+  quay.io/smashwilson/azurefire-tls:{{ tls.tag }}
 EOF
 
 cat <<EOF | sudo tee /etc/systemd/system/azurefire-tls.timer > /dev/null
@@ -108,7 +108,7 @@ docker run \
   --env PRIOR_ADDRESSES="{{ pushbot.prior_addresses }}" \
   --env MAGICAL_WEAK_SPOT_TOKEN="{{ secrets.magical_weak_spot_token }}" \
   --name pushbot \
-  quay.io/smashwilson/pushbot:{{ pushbot.branch }}
+  quay.io/smashwilson/pushbot:{{ pushbot.tag }}
 
 docker run \
   --restart=unless-stopped \
@@ -119,9 +119,9 @@ docker run \
   --env S3_BUCKET_NAME=azurefire-tls \
   --publish 443:443 \
   --publish 80:80 \
-  quay.io/smashwilson/azurefire-nginx:{{ nginx.branch }}
+  quay.io/smashwilson/azurefire-nginx:{{ nginx.tag }}
 
 # Output service versions for the Slack notification
 
-report_versions pushbot "{{ pushbot.branch }}"
-report_versions azurefire-nginx "{{ nginx.branch }}"
+report_versions pushbot "{{ pushbot.tag }}"
+report_versions azurefire-nginx "{{ nginx.tag }}"


### PR DESCRIPTION
Reword configuration file options and template variables as `_tag` instead of `_build`, because they're actually used to generate Docker image tags.