### PR TITLE
Upgrade actions

### DIFF
--- a/.github/workflows/shipit.yml
+++ b/.github/workflows/shipit.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: setup python
-      uses: actions/setup-python@v1.2.0
+      uses: actions/setup-python@v3
       with:
         python-version: 3.6
     - name: install dependencies


### PR DESCRIPTION
Deployment is failing because `actions/setup-python` is out of date. Let's bump these and see if that fixes things.